### PR TITLE
fix: remove unreachable code warning in spectator

### DIFF
--- a/Spectator/Runtime/SpectatorController.cs
+++ b/Spectator/Runtime/SpectatorController.cs
@@ -39,8 +39,9 @@ namespace Innoactive.Creator.UX
         {
 #if ENABLE_LEGACY_INPUT_MANAGER
             return Input.GetKeyDown(key);
-#endif
+#else
             return false;
+#endif
         }
     }
 }


### PR DESCRIPTION


### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

Remove unreachable code warning in SpectatorController.

![image](https://user-images.githubusercontent.com/6626589/103298773-55cc3f80-49fb-11eb-8a0f-dc9a234bd21c.png)

**Fixes**: Unreachable Code Warning in Unity console.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update