### PR TITLE
fix: compilation error when xrit and the new input system are enabled

### DIFF
--- a/Runtime/CourseController/StandaloneMenuHandler.cs
+++ b/Runtime/CourseController/StandaloneMenuHandler.cs
@@ -68,7 +68,7 @@ namespace Innoactive.Creator.UX
             transform.SetPositionAndRotation(position, rotation);
             dropdownsList.AddRange(GetComponentsInChildren<TMP_Dropdown>());
             
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && XRIT_0_10_OR_NEWER
             UnityEngine.InputSystem.UI.InputSystemUIInputModule inputSystem = FindObjectOfType<UnityEngine.InputSystem.UI.InputSystemUIInputModule>();
 
             if (inputSystem)


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: 

The following error is produced when `XR Interaction Toolkit` is set to the v0.9.4 and Unity is set up to use either the `new input system` or `both`:
![image](https://user-images.githubusercontent.com/6911992/106451456-e5e02780-6486-11eb-9f64-d23499142c25.png)


### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->


Try different combinations of XRIT versions and input system set ups.