### PR TITLE
fix: do not throw error when the user did not set a custom prefab

### DIFF
--- a/Editor/CourseController/UI/CourseMenuSpawnerEditor.cs
+++ b/Editor/CourseController/UI/CourseMenuSpawnerEditor.cs
@@ -31,19 +31,19 @@ namespace Innoactive.CreatorEditor.UX
             GUI.enabled = false;
             EditorGUILayout.ObjectField("Script", MonoScript.FromMonoBehaviour((CourseMenuSpawner)target), typeof(CourseMenuSpawner), false);
             EditorGUILayout.ObjectField(new GUIContent("Default prefab", "Default menu prefab. If you want to change the menu that is spawned, set a custom prefab instead."), defaultPrefabProperty.objectReferenceValue, typeof(GameObject), false);
-            
+
             GUI.enabled = useCustomPrefab == false && Application.isPlaying == false;
-            
+
             GUI.enabled = !Application.isPlaying;
 
             useCustomPrefab = EditorGUILayout.Toggle(new GUIContent("Use custom prefab", "Use a custom menu prefab instead of default"), useCustomPrefabProperty.boolValue);
-            
+
             if (useCustomPrefab)
             {
-                customPrefab = EditorGUILayout.ObjectField(new GUIContent("Custom prefab", "Custom menu prefab"), customPrefabProperty.objectReferenceValue, typeof(GameObject), false) as GameObject;
+                customPrefab = EditorGUILayout.ObjectField(new GUIContent("Custom prefab", "Custom menu prefab. If you leave this empty no menu will be spawned."), customPrefabProperty.objectReferenceValue, typeof(GameObject), false) as GameObject;
                 customPrefabProperty.objectReferenceValue = customPrefab;
             }
-            
+
             useCustomPrefabProperty.boolValue = useCustomPrefab;
             serializedObject.ApplyModifiedProperties();
         }

--- a/Runtime/CourseController/CourseMenuSpawner.cs
+++ b/Runtime/CourseController/CourseMenuSpawner.cs
@@ -9,10 +9,10 @@ namespace Innoactive.Creator.UX
     {
         [SerializeField]
         private GameObject defaultPrefab;
-        
-        [SerializeField] 
+
+        [SerializeField]
         private bool useCustomPrefab;
-        
+
         [SerializeField]
         private GameObject customPrefab;
 
@@ -28,7 +28,7 @@ namespace Innoactive.Creator.UX
             {
                 if (customPrefab == null)
                 {
-                    Debug.LogError("Custom prefab in CourseMenuSpawner is not set.");
+                    Debug.LogWarning("Custom prefab in CourseMenuSpawner is not set. No trainer menu will be spawned.");
                     return;
                 }
 


### PR DESCRIPTION
### Description
Throw a warning not an error when a user did not set a custom prefab in the course spawner allowing them to use an already set menu in the scene. This should happen very rarely, therefore I do not want to overengineer that with an additional bool or something.