### PR TITLE
Feature/set course controller with highest prio as default

### DIFF
--- a/Editor/CourseController/CourseControllerSceneSetup.cs
+++ b/Editor/CourseController/CourseControllerSceneSetup.cs
@@ -1,4 +1,7 @@
-﻿namespace Innoactive.CreatorEditor.UX
+﻿using Innoactive.Creator.UX;
+using UnityEngine;
+
+namespace Innoactive.CreatorEditor.UX
 {
     /// <summary>
     /// Will be called on OnSceneSetup to add the course controller menu.
@@ -14,7 +17,10 @@
         /// <inheritdoc />
         public override void Setup()
         {
-            SetupPrefab("[COURSE_CONTROLLER]");
+            GameObject courseController = FindPrefab("[COURSE_CONTROLLER]");
+            courseController.name = courseController.name.Replace("(Clone)", string.Empty);
+            courseController.GetComponent<CourseControllerSetup>().ResetToDefault();
+            Object.Instantiate(courseController);
         }
     }
 }

--- a/Editor/CourseController/CourseControllerSceneSetup.cs
+++ b/Editor/CourseController/CourseControllerSceneSetup.cs
@@ -1,4 +1,5 @@
-﻿using Innoactive.Creator.UX;
+﻿using Innoactive.Creator.Unity;
+using Innoactive.Creator.UX;
 using UnityEngine;
 
 namespace Innoactive.CreatorEditor.UX
@@ -19,7 +20,7 @@ namespace Innoactive.CreatorEditor.UX
         {
             GameObject courseController = FindPrefab("[COURSE_CONTROLLER]");
             courseController.name = courseController.name.Replace("(Clone)", string.Empty);
-            courseController.GetComponent<CourseControllerSetup>().ResetToDefault();
+            courseController.GetOrAddComponent<CourseControllerSetup>().ResetToDefault();
             Object.Instantiate(courseController);
         }
     }

--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -140,7 +140,7 @@ namespace Innoactive.Creator.UX
         }
 
         /// <summary>
-        /// Resets the <cref name="courseControllerQualifiedName"></cref> to the name of the course controller with the highest priority.
+        /// Resets the <cref name="courseControllerQualifiedName"/> to the name of the course controller with the highest priority.
         /// </summary>
         /// <remarks>This may be used when instantiating a course controller prefab to make sure the default course controller is used.</remarks>
         public void ResetToDefault()

--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -138,5 +138,15 @@ namespace Innoactive.Creator.UX
         {
             enforcedCourseController = courseController;
         }
+
+        /// <summary>
+        /// Resets the <cref name="courseControllerQualifiedName"></cref> to the name of the course controller with the highest priority.
+        /// </summary>
+        /// <remarks>This may be used when instantiating a course controller prefab to make sure the default course controller is used.</remarks>
+        public void ResetToDefault()
+        {
+            Type courseControllerType = RetrieveDefaultControllerType();
+            courseControllerQualifiedName = courseControllerType.Name;
+        }
     }
 }


### PR DESCRIPTION
### Description
When setting up the training scene the Course Controller was always set to the one in the prefab (Default) instead of the one with the highest priority which is actually intended to be the default loaded one.

**Fixes**: TRNG-1455
