### PR TITLE
chore: change toggle overlay hotkey in spectator settings

### DIFF
--- a/Runtime/Spectator/SpectatorSettings.cs
+++ b/Runtime/Spectator/SpectatorSettings.cs
@@ -13,6 +13,6 @@ namespace Innoactive.Creator.UX
         /// <summary>
         /// Hotkey to toggle UI overlay.
         /// </summary>
-        public KeyCode ToggleOverlay = KeyCode.W;
+        public KeyCode ToggleOverlay = KeyCode.F9;
     }
 }


### PR DESCRIPTION
### Description
Changed hotkey for the overlay toggle in spectator settings

**Fixes**: # 1400

Notes: In an already existing project you have to delete the spectator settings in Resources