### PR TITLE
fix: language selector now shows the correct language

### DIFF
--- a/Runtime/CourseController/BaseCourseControllerMenu.cs
+++ b/Runtime/CourseController/BaseCourseControllerMenu.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Innoactive.Creator.Core;
+using Innoactive.Creator.Core.Internationalization;
+using UnityEngine;
+
+namespace Innoactive.Creator.UX
+{
+    public abstract class BaseCourseControllerMenu : MonoBehaviour
+    {
+        protected List<string> localizationFileNames = null;
+        
+        protected virtual List<string> FetchAvailableLocalizationsForTraining()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+            parameters.Add(LocalizationReader.KeyCourseName, CourseRunner.Current.Data.Name);
+            return LocalizationUtils.FindAvailableLanguagesForConfig(GetLocalizationConfig(), parameters);
+        }
+        
+        protected virtual string GetSelectedLanguage()
+        {
+            if (string.IsNullOrEmpty(LanguageSettings.Instance.ActiveLanguage) == false)
+            {
+                return LanguageSettings.Instance.ActiveLanguage;
+            }
+
+            if (localizationFileNames == null)
+            {
+                localizationFileNames = FetchAvailableLocalizationsForTraining();
+            }
+            
+            if (localizationFileNames.Contains(LocalizationUtils.GetSystemLanguageAsTwoLetterIsoCode().ToLower()))
+            {
+                return LocalizationUtils.GetSystemLanguageAsTwoLetterIsoCode();
+            }
+            return LanguageSettings.Instance.DefaultLanguage;
+        }
+        
+        protected virtual LocalizationConfig GetLocalizationConfig()
+        {
+            ICourseController controller = FindObjectOfType<CourseControllerSetup>().CurrentCourseController;
+            if (controller is ILocalizationProvider localizationProvider)
+            {
+                return localizationProvider.LocalizationConfig;
+            }
+            
+            return Resources.Load<LocalizationConfig>(LocalizationConfig.DefaultLocalizationConfig);
+        }
+    }
+}

--- a/Runtime/CourseController/BaseCourseControllerMenu.cs
+++ b/Runtime/CourseController/BaseCourseControllerMenu.cs
@@ -10,11 +10,25 @@ namespace Innoactive.Creator.UX
     /// </summary>
     public abstract class BaseCourseControllerMenu : MonoBehaviour
     {
+        private List<string> localizationFileNames;
+        
         /// <summary>
         /// Localized file names.
         /// </summary>
-        protected List<string> localizationFileNames = null;
-        
+        protected List<string> LocalizationFileNames
+        {
+            get
+            {
+                if (localizationFileNames == null)
+                {
+                    localizationFileNames = FetchAvailableLocalizationsForTraining();
+                }
+
+                return localizationFileNames;
+            }
+            set => localizationFileNames = value;
+        }
+
         /// <summary>
         /// Returns all available localizations for the active training.
         /// </summary>
@@ -37,12 +51,7 @@ namespace Innoactive.Creator.UX
                 return LanguageSettings.Instance.ActiveLanguage;
             }
 
-            if (localizationFileNames == null)
-            {
-                localizationFileNames = FetchAvailableLocalizationsForTraining();
-            }
-            
-            if (localizationFileNames.Contains(LocalizationUtils.GetSystemLanguageAsTwoLetterIsoCode().ToLower()))
+            if (LocalizationFileNames.Contains(LocalizationUtils.GetSystemLanguageAsTwoLetterIsoCode().ToLower()))
             {
                 return LocalizationUtils.GetSystemLanguageAsTwoLetterIsoCode();
             }

--- a/Runtime/CourseController/BaseCourseControllerMenu.cs
+++ b/Runtime/CourseController/BaseCourseControllerMenu.cs
@@ -5,10 +5,20 @@ using UnityEngine;
 
 namespace Innoactive.Creator.UX
 {
+    /// <summary>
+    /// Base class for the course controller menu.
+    /// </summary>
     public abstract class BaseCourseControllerMenu : MonoBehaviour
     {
+        /// <summary>
+        /// Localized file names.
+        /// </summary>
         protected List<string> localizationFileNames = null;
         
+        /// <summary>
+        /// Returns all available localizations for the active training.
+        /// </summary>
+        /// <returns></returns>
         protected virtual List<string> FetchAvailableLocalizationsForTraining()
         {
             Dictionary<string, string> parameters = new Dictionary<string, string>();
@@ -16,6 +26,10 @@ namespace Innoactive.Creator.UX
             return LocalizationUtils.FindAvailableLanguagesForConfig(GetLocalizationConfig(), parameters);
         }
         
+        /// <summary>
+        /// Returns the language which should be selected right now.
+        /// </summary>
+        /// <returns></returns>
         protected virtual string GetSelectedLanguage()
         {
             if (string.IsNullOrEmpty(LanguageSettings.Instance.ActiveLanguage) == false)
@@ -35,6 +49,9 @@ namespace Innoactive.Creator.UX
             return LanguageSettings.Instance.DefaultLanguage;
         }
         
+        /// <summary>
+        /// Returns the used <see cref="LocalizationConfig"/>.
+        /// </summary>
         protected virtual LocalizationConfig GetLocalizationConfig()
         {
             ICourseController controller = FindObjectOfType<CourseControllerSetup>().CurrentCourseController;

--- a/Runtime/CourseController/BaseCourseControllerMenu.cs.meta
+++ b/Runtime/CourseController/BaseCourseControllerMenu.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4de601be545b4e7fabbdc1bc5509f1f1
+timeCreated: 1616509610

--- a/Runtime/CourseController/CourseControllerMenu.cs
+++ b/Runtime/CourseController/CourseControllerMenu.cs
@@ -222,14 +222,14 @@ namespace Innoactive.Creator.UX
             CourseRunner.Initialize(trainingCourse);
         }
 
-
         protected virtual void LoadLocalizationForTraining(string coursePath)
         {
             string course = Path.GetFileNameWithoutExtension(coursePath);
 
             LanguageSettings.Instance.ActiveLanguage = selectedLanguage;
+
             // Find the correct file name of the current selected language.
-            string language = localizationFileNames.Find(f => string.Equals(f, selectedLanguage, StringComparison.CurrentCultureIgnoreCase));
+            string language = LocalizationFileNames.Find(f => string.Equals(f, selectedLanguage, StringComparison.CurrentCultureIgnoreCase));
             
             Localization.LoadLocalization(GetLocalizationConfig(), language, course);
         }
@@ -377,7 +377,7 @@ namespace Innoactive.Creator.UX
             List<string> supportedLanguages = new List<string>();
 
             // Add each language in capital letters to the list of supported languages.
-            foreach (string file in localizationFileNames)
+            foreach (string file in LocalizationFileNames)
             {
                 supportedLanguages.Add(file.ToUpper());
             }
@@ -399,10 +399,11 @@ namespace Innoactive.Creator.UX
                 {
                     selectedLanguage = supportedLanguages[languagePicker.value];
                 }
-                else if (string.IsNullOrEmpty(LanguageSettings.Instance.ActiveLanguage) == false)
+                else
                 {
-                    languagePicker.AddOptions(new List<string>() { LanguageSettings.Instance.ActiveLanguage.ToUpper() });
-                    selectedLanguage = LanguageSettings.Instance.ActiveLanguage;
+                    supportedLanguages.Add(LanguageSettings.Instance.ActiveOrDefaultLanguage.ToUpper());
+                    languagePicker.AddOptions(new List<string>() { supportedLanguages[0] });
+                    selectedLanguage = supportedLanguages[0];
                 }
             }
 
@@ -412,6 +413,10 @@ namespace Innoactive.Creator.UX
                 // Set the supported language based on the user selection.
                 selectedLanguage = supportedLanguages[itemIndex];
                 LanguageSettings.Instance.ActiveLanguage = selectedLanguage;
+                
+                languagePicker.value = itemIndex;
+                languagePicker.RefreshShownValue();
+                
                 // Load the training and localize it to the selected language.
                 LoadLocalizationForTraining(RuntimeConfigurator.Instance.GetSelectedCourse());
                 SetupTraining();

--- a/Runtime/CourseController/StandaloneCourseMenu.cs
+++ b/Runtime/CourseController/StandaloneCourseMenu.cs
@@ -20,7 +20,7 @@ namespace Innoactive.Creator.UX
     /// <summary>
     /// Standalone controller class for an example of a custom training overlay with audio and localization.
     /// </summary>
-    public class StandaloneCourseMenu : MonoBehaviour
+    public class StandaloneCourseMenu : BaseCourseControllerMenu
     {
         #region UI elements
         [Tooltip("Chapter picker dropdown.")]
@@ -88,8 +88,6 @@ namespace Innoactive.Creator.UX
         [SerializeField]
         private string fallbackLanguage = "EN";
 
-        private List<string> localizationFileNames;
-
         private string selectedLanguage;
         private FieldInfo skipStepPickerEditorValueField;
 
@@ -99,22 +97,8 @@ namespace Innoactive.Creator.UX
 
         private void Awake()
         {
-            // Get all the available localization files for the selected training.
-            localizationFileNames = FetchAvailableLocalizationsForTraining();
-            
-            if (LanguageSettings.Instance.ActiveLanguage != null)
-            {
-                selectedLanguage = LanguageSettings.Instance.ActiveLanguage;
-            }
-            else if (localizationFileNames.Contains(LocalizationUtils.GetSystemLanguageAsTwoLetterIsoCode().ToLower()))
-            {
-                selectedLanguage = LocalizationUtils.GetSystemLanguageAsTwoLetterIsoCode();
-                LanguageSettings.Instance.ActiveLanguage = selectedLanguage;
-            }
-            else
-            {
-                LanguageSettings.Instance.ActiveLanguage = LanguageSettings.Instance.DefaultLanguage;
-            }
+            selectedLanguage = GetSelectedLanguage();
+            LanguageSettings.Instance.ActiveLanguage = selectedLanguage;
             
             // Load the localization for the current selected course.
             LoadLocalizationForTraining(RuntimeConfigurator.Instance.GetSelectedCourse());
@@ -205,19 +189,6 @@ namespace Innoactive.Creator.UX
             CourseRunner.Initialize(trainingCourse);
         }
 
-        protected virtual List<string> FetchAvailableLocalizationsForTraining()
-        {
-            // Save all existing localization files in a list.
-            List<string> availableLocalizations = new List<string>();
-
-            Dictionary<string, string> parameters = new Dictionary<string, string>();
-            parameters.Add(LocalizationReader.KeyCourseName, CourseRunner.Current.Data.Name);
-            availableLocalizations = LocalizationUtils.FindAvailableLanguagesForConfig(GetLocalizationConfig(), parameters);
-            
-            // Return the list of all available valid localizations.
-            return availableLocalizations;
-        }
-
         protected virtual void LoadLocalizationForTraining(string coursePath)
         {
             string course = Path.GetFileNameWithoutExtension(coursePath);
@@ -229,7 +200,7 @@ namespace Innoactive.Creator.UX
             Localization.LoadLocalization(GetLocalizationConfig(), language, course);
         }
         
-        protected virtual LocalizationConfig GetLocalizationConfig()
+        protected override LocalizationConfig GetLocalizationConfig()
         {
             ICourseController controller = FindObjectOfType<CourseControllerSetup>().CurrentCourseController;
             if (controller is ILocalizationProvider localizationProvider)

--- a/Runtime/CourseController/StandaloneCourseMenu.cs
+++ b/Runtime/CourseController/StandaloneCourseMenu.cs
@@ -195,7 +195,7 @@ namespace Innoactive.Creator.UX
 
             LanguageSettings.Instance.ActiveLanguage = selectedLanguage;
             // Find the correct file name of the current selected language.
-            string language = localizationFileNames.Find(f => string.Equals(f, selectedLanguage, StringComparison.CurrentCultureIgnoreCase));
+            string language = LocalizationFileNames.Find(f => string.Equals(f, selectedLanguage, StringComparison.CurrentCultureIgnoreCase));
             
             Localization.LoadLocalization(GetLocalizationConfig(), language, course);
         }
@@ -354,7 +354,7 @@ namespace Innoactive.Creator.UX
             List<string> supportedLanguages = new List<string>();
 
             // Add each language in capital letters to the list of supported languages.
-            foreach (string file in localizationFileNames)
+            foreach (string file in LocalizationFileNames)
             {
                 supportedLanguages.Add(file.ToUpper());
             }


### PR DESCRIPTION
### Description
empty check for active language was only checking null not "" which caused the problem. Fixed, refactored a little bit so standalone and default menu have less duplicated code.