### PR TITLE
fix: course controller was spawned a second time on scene setup

### DIFF
--- a/Editor/CourseController/CourseControllerSceneSetup.cs
+++ b/Editor/CourseController/CourseControllerSceneSetup.cs
@@ -18,9 +18,11 @@ namespace Innoactive.CreatorEditor.UX
         /// <inheritdoc />
         public override void Setup()
         {
-            GameObject courseController = Object.Instantiate(FindPrefab("[COURSE_CONTROLLER]"));
-            courseController.GetOrAddComponent<CourseControllerSetup>().ResetToDefault();
-            courseController.name = courseController.name.Replace("(Clone)", string.Empty);
+            GameObject courseController = SetupPrefab("[COURSE_CONTROLLER]");
+            if (courseController != null)
+            {
+                courseController.GetOrAddComponent<CourseControllerSetup>().ResetToDefault();
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
Course controller object was spawned a second time if already existent in the scene during scene setup run

Related PRs:
https://github.com/Innoactive/Creator/pull/269