### PR TITLE
fix: course controller setup now uses concrete implementations

### DIFF
--- a/Editor/CourseController/UI/CourseControllerSetupEditor.cs
+++ b/Editor/CourseController/UI/CourseControllerSetupEditor.cs
@@ -39,7 +39,7 @@ namespace Innoactive.CreatorEditor.UX
             customPrefab = (GameObject) customPrefabProperty.objectReferenceValue;
             setupObject = (CourseControllerSetup) serializedObject.targetObject;
 
-            availableCourseControllers = ReflectionUtils.GetFinalImplementationsOf<ICourseController>()
+            availableCourseControllers = ReflectionUtils.GetConcreteImplementationsOf<ICourseController>()
                 .Select(c => (ICourseController) ReflectionUtils.CreateInstanceOfType(c)).OrderByDescending(controller => controller.Priority).ToArray();
 
             availableCourseControllerNames = availableCourseControllers.Select(controller => controller.Name).ToArray();

--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -101,7 +101,7 @@ namespace Innoactive.Creator.UX
 
         private Type RetrieveDefaultControllerType()
         {
-            return ReflectionUtils.GetFinalImplementationsOf<ICourseController>()
+            return ReflectionUtils.GetConcreteImplementationsOf<ICourseController>()
                 .Select(c => (ICourseController) ReflectionUtils.CreateInstanceOfType(c)).OrderByDescending(controller => controller.Priority)
                 .First()
                 .GetType();


### PR DESCRIPTION
### Description
When overriding an existing Course Controller (e.g. Advanced Course Controller) to add more logic or to adjust it in a template, the Advanced one will not be shown anymore in the dropdown. Therefore, I changed it to Concrete Implementations instead of Final