### PR TITLE
fix: add playerinput before inputcontroller in required components

### DIFF
--- a/Runtime/CourseController/Controllers/UIBaseCourseController.cs
+++ b/Runtime/CourseController/Controllers/UIBaseCourseController.cs
@@ -33,7 +33,7 @@ namespace Innoactive.Creator.UX
         /// <inheritdoc />
         public override List<Type> GetRequiredSetupComponents()
         {
-            return new List<Type> {typeof(CourseMenuSpawner), typeof(InputController), typeof(PlayerInput)};
+            return new List<Type> {typeof(CourseMenuSpawner), typeof(PlayerInput), typeof(InputController)};
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
### Description
Give: Create new scene and set it up as training scene. When starting the scene now the CourseController throws an NRE because the InputController cannot find the PlayerInput OnEnable. This is because PlayerInput is added _after_ InputController in the required components of the course controller. Changing the order fixes this issue.

**Fixes**: CREATOR-340 

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)