### PR TITLE
Fix/workaround to trigger reload of cc

### DIFF
--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -140,7 +140,7 @@ namespace Innoactive.Creator.UX
             CourseControllerSetup setup = FindObjectOfType<CourseControllerSetup>();
             List<Type> currentTypes = setup.GetComponents<Component>().Select(c => c.GetType()).ToList();
             ICourseController cc = setup.GetCourseControllerFromType();
-            bool courseControllerHasMissingComponents = !currentTypes.Except(cc.GetRequiredSetupComponents()).Any();
+            bool courseControllerHasMissingComponents = currentTypes.Except(cc.GetRequiredSetupComponents()).Any();
             if (courseControllerHasMissingComponents)
             {
                 Selection.activeObject = setup;

--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -131,22 +131,6 @@ namespace Innoactive.Creator.UX
         }
 
         /// <summary>
-        /// Workaround to set the focus to the CourseControllerSetup if it has missing components that are required by the CourseController.
-        /// </summary>
-        [UnityEditor.Callbacks.DidReloadScripts]
-        private static void OnScriptsReloaded()
-        {
-            CourseControllerSetup setup = FindObjectOfType<CourseControllerSetup>();
-            List<Type> currentTypes = setup.GetComponents<Component>().Select(c => c.GetType()).ToList();
-            ICourseController cc = setup.GetCourseControllerFromType();
-            bool courseControllerHasMissingComponents = currentTypes.Except(cc.GetRequiredSetupComponents()).Any();
-            if (courseControllerHasMissingComponents)
-            {
-                Selection.activeObject = setup;
-            }
-        }
-
-        /// <summary>
         /// Enforces the given controller to be used, if possible.
         /// </summary>
         /// <param name="courseController">Controller to be used.</param>
@@ -166,5 +150,23 @@ namespace Innoactive.Creator.UX
             Type courseControllerType = RetrieveDefaultControllerType();
             courseControllerQualifiedName = courseControllerType.Name;
         }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Workaround to set the focus to the CourseControllerSetup if it has missing components that are required by the CourseController.
+        /// </summary>
+        [UnityEditor.Callbacks.DidReloadScripts]
+        private static void OnScriptsReloaded()
+        {
+            CourseControllerSetup setup = FindObjectOfType<CourseControllerSetup>();
+            List<Type> currentTypes = setup.GetComponents<Component>().Select(c => c.GetType()).ToList();
+            ICourseController cc = setup.GetCourseControllerFromType();
+            bool courseControllerHasMissingComponents = currentTypes.Except(cc.GetRequiredSetupComponents()).Any();
+            if (courseControllerHasMissingComponents)
+            {
+                Selection.activeObject = setup;
+            }
+        }
+#endif
     }
 }

--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using UnityEngine;
 using Innoactive.Creator.Core.Utils;
 using UnityEditor;
-using UnityEngine.SceneManagement;
 
 namespace Innoactive.Creator.UX
 {

--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -160,11 +160,12 @@ namespace Innoactive.Creator.UX
         {
             CourseControllerSetup setup = FindObjectOfType<CourseControllerSetup>();
             List<Type> currentTypes = setup.GetComponents<Component>().Select(c => c.GetType()).ToList();
-            ICourseController cc = setup.GetCourseControllerFromType();
-            bool courseControllerHasMissingComponents = currentTypes.Except(cc.GetRequiredSetupComponents()).Any();
+            ICourseController courseController = setup.GetCourseControllerFromType();
+            bool courseControllerHasMissingComponents = courseController.GetRequiredSetupComponents().Except(currentTypes).Any();
             if (courseControllerHasMissingComponents)
             {
                 Selection.activeObject = setup;
+                Debug.LogWarning($"Automatically added missing required components to {setup}.");
             }
         }
 #endif

--- a/Runtime/CourseController/CourseControllerSetup.cs
+++ b/Runtime/CourseController/CourseControllerSetup.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Innoactive.Creator.Core.Utils;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace Innoactive.Creator.UX
 {


### PR DESCRIPTION
### Description
When updating an old project the course controller might have missing scripts. A focus on the coursecontrollersetup is needed. This is a workaround to enforce this reload after scripts are loaded.